### PR TITLE
Porting to Linux

### DIFF
--- a/cpp/graphics.cpp
+++ b/cpp/graphics.cpp
@@ -1,3 +1,6 @@
+#ifdef  __LINUX__
+	#include <unistd.h>
+#endif
 #include "graphics.h"
 #include "effects.h"
 #include "controllers.h"
@@ -63,12 +66,23 @@ void quitSDL()
 
 void ShowAlert(const wchar_t* title, const wchar_t* text)
 {
-	 MessageBoxW(NULL, text, title, MB_OK);
+#ifdef __linux__
+	char title2[100], text2[500];
+	wcstombs(title2,title,100);
+	wcstombs(text2,text,500);
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, title2, text2, window);
+#else
+  MessageBoxW(NULL, text, title, MB_OK);
+#endif
 }
 
 void getCurrentDir(char* filename, int size)
 {
+#ifdef  __LINUX__
+	getcwd(filename, size);
+#else
 	GetCurrentDirectory(size, filename);
+#endif
 }
 
 void getOpenFile(char* filename, int size)
@@ -271,4 +285,3 @@ SDL_Color getDarkerColor(SDL_Color color)
 	color.b=(color.b+127)/2;
 	return color;
 }
-

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -263,22 +263,34 @@ bool launchSuperCollider()
 		if(i==1) return false;
 	}
 	
-	char tab[MAX_PATH*2+10];
-	sprintf(tab, "-d \"%s\" \"%s\\%s\"", sclangPathDirectory, currentDir, SC_MAIN_FILE);
+	char main_scd_path[MAX_PATH+10];
+	#ifdef __LINUX__
+		char dir_sep_char = '/';
+	#else
+		char dir_sep_char = '\\';
+	#endif
+	sprintf(main_scd_path, "%s%c%s", currentDir, dir_sep_char, SC_MAIN_FILE);
 	
-	//przykładowe polecenie: "C:\Program Files (x86)\SuperCollider-3.6.6\sclang.exe" -d "C:\Program Files (x86)\SuperCollider-3.6.6" "C:\Users\praktykant\CELLOTRONICUM\main.scd"
 	
-	printf("Executing: %s %s...\n", sclangPath, tab);
 	
 	#ifdef __LINUX__
-		if(fork()){
-			execlp(sclangPath,tab);
+		if(!fork()){
+			printf("Executing: %s %s...\n", sclangPath, main_scd_path);
+			//execlp(sclangPath,sclangPath,"-d","/usr/share/SuperCollider",main_scd_path,NULL);
+			execlp(sclangPath,sclangPath,main_scd_path,NULL);
+			// execlp never returns
 		}
 
 	#else
+		char tab[MAX_PATH*2+10];
+		sprintf(tab, "-d \"%s\" \"%s\"", sclangPathDirectory, main_scd_path);
+
+		//przykładowe polecenie: "C:\Program Files (x86)\SuperCollider-3.6.6\sclang.exe" -d "C:\Program Files (x86)\SuperCollider-3.6.6" "C:\Users\praktykant\CELLOTRONICUM\main.scd"
+		printf("Executing: %s %s...\n", sclangPath, tab);
 		ShellExecute(NULL, "open", sclangPath, tab, NULL, SW_SHOWDEFAULT);
 	#endif
 	
+
 	return true;
 }
 
@@ -299,10 +311,17 @@ bool getSCPath()
 		fgets(sclangPath, MAX_PATH, pathFile);
 		if(existsTest(sclangPath))
 		{
+			fclose(pathFile);
 			return true;
 		}
 	}
-	fclose(pathFile);
+
+#ifdef __LINUX__
+	if(existsTest("/usr/bin/sclang")){
+		strcpy(sclangPath,"/usr/bin/sclang");
+		return true;
+	}
+#endif
 	
 	ShowAlert(L"SuperCollider Path", L"To launch program you must provide path to sclang in SuperCollider folder.");
 	getOpenFile(sclangPath, MAX_PATH);

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -2,6 +2,9 @@
 #include <cstring>
 #include <chrono>
 #include <thread>
+#ifdef  __LINUX__
+	#include <unistd.h>
+#endif
 #include "osc.h"
 #include "effects.h"
 #include "effectsdef.h"
@@ -267,7 +270,14 @@ bool launchSuperCollider()
 	
 	printf("Executing: %s %s...\n", sclangPath, tab);
 	
-	ShellExecute(NULL, "open", sclangPath, tab, NULL, SW_SHOWDEFAULT);
+	#ifdef __LINUX__
+		if(fork()){
+			execlp(sclangPath,tab);
+		}
+
+	#else
+		ShellExecute(NULL, "open", sclangPath, tab, NULL, SW_SHOWDEFAULT);
+	#endif
 	
 	return true;
 }


### PR DESCRIPTION
This branch contains changes necessary to sucessfully compile the sources on a POSIX system. It also allows to run the application on Linux. This includes:
- Providing POSIX alternatives to WinAPI routines.
- Switching from WinAPI message box to cross-platform SDL message box.
- Automatic detection of sclang interpreter binary in /usr/bin/sclang, where it is most likely to be installed.
